### PR TITLE
Fix contract reentrancy vulnerabilities and security hardening

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -5,15 +5,16 @@ authors = ["Gbolahan Akande <geakande@gmail.com>"]
 telemetry = true
 cache_dir = "./.cache"
 
-[contracts.promo-manager]
-path = "contracts/promo-manager.clar"
-clarity_version = 4
-epoch = '3.0'
-
 [contracts.user-profiles]
 path = "contracts/user-profiles.clar"
 clarity_version = 4
 epoch = '3.0'
+
+[contracts.promo-manager]
+path = "contracts/promo-manager.clar"
+clarity_version = 4
+epoch = '3.0'
+depends_on = ["user-profiles"]
 
 [contracts.stats-tracker]
 path = "contracts/stats-tracker.clar"

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -20,6 +20,7 @@ depends_on = ["user-profiles"]
 path = "contracts/stats-tracker.clar"
 clarity_version = 4
 epoch = '3.0'
+depends_on = ["promo-manager"]
 
 [contracts.vote-handler]
 path = "contracts/vote-handler.clar"
@@ -30,21 +31,25 @@ epoch = '3.0'
 path = "contracts/funds-keeper.clar"
 clarity_version = 4
 epoch = '3.0'
+depends_on = ["promo-manager"]
 
 [contracts.cash-distributor]
 path = "contracts/cash-distributor.clar"
 clarity_version = 4
 epoch = '3.0'
+depends_on = ["funds-keeper"]
 
 [contracts.threat-detector]
 path = "contracts/threat-detector.clar"
 clarity_version = 4
 epoch = '3.0'
+depends_on = ["stats-tracker"]
 
 [contracts.audience-selector]
 path = "contracts/audience-selector.clar"
 clarity_version = 4
 epoch = '3.0'
+depends_on = ["user-profiles"]
 
 [contracts.partner-hub]
 path = "contracts/partner-hub.clar"

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -8,47 +8,47 @@ cache_dir = "./.cache"
 [contracts.promo-manager]
 path = "contracts/promo-manager.clar"
 clarity_version = 4
-epoch = 'latest'
+epoch = '3.0'
 
 [contracts.user-profiles]
 path = "contracts/user-profiles.clar"
 clarity_version = 4
-epoch = 'latest'
+epoch = '3.0'
 
 [contracts.stats-tracker]
 path = "contracts/stats-tracker.clar"
 clarity_version = 4
-epoch = 'latest'
+epoch = '3.0'
 
 [contracts.vote-handler]
 path = "contracts/vote-handler.clar"
 clarity_version = 4
-epoch = 'latest'
+epoch = '3.0'
 
 [contracts.funds-keeper]
 path = "contracts/funds-keeper.clar"
 clarity_version = 4
-epoch = 'latest'
+epoch = '3.0'
 
 [contracts.cash-distributor]
 path = "contracts/cash-distributor.clar"
 clarity_version = 4
-epoch = 'latest'
+epoch = '3.0'
 
 [contracts.threat-detector]
 path = "contracts/threat-detector.clar"
 clarity_version = 4
-epoch = 'latest'
+epoch = '3.0'
 
 [contracts.audience-selector]
 path = "contracts/audience-selector.clar"
 clarity_version = 4
-epoch = 'latest'
+epoch = '3.0'
 
 [contracts.partner-hub]
 path = "contracts/partner-hub.clar"
 clarity_version = 4
-epoch = 'latest'
+epoch = '3.0'
 
 [repl.analysis]
 passes = ["check_checker"]

--- a/contracts/audience-selector.clar
+++ b/contracts/audience-selector.clar
@@ -195,6 +195,14 @@
       (merge segment { tag-count: (+ current-tags u1) })
     )
 
+    (print {
+      event: "segment-tag-added",
+      segment-id: segment-id,
+      tag: tag,
+      tag-index: current-tags,
+      timestamp: stacks-block-time
+    })
+
     (ok true)
   )
 )

--- a/contracts/audience-selector.clar
+++ b/contracts/audience-selector.clar
@@ -330,6 +330,8 @@
     (asserts! (is-admin) ERR_UNAUTHORIZED)
     (asserts! (<= score u100) ERR_INVALID_INPUT)
     (asserts! (is-some (map-get? segments { segment-id: segment-id })) ERR_NOT_FOUND)
+    ;; Verify segment is still active
+    (asserts! (default-to false (get is-active (map-get? segments { segment-id: segment-id }))) ERR_NOT_FOUND)
     ;; Verify publisher has a registered profile
     (asserts! (is-some (map-get? publisher-profiles { publisher: publisher })) ERR_NOT_FOUND)
 

--- a/contracts/audience-selector.clar
+++ b/contracts/audience-selector.clar
@@ -241,6 +241,8 @@
   )
     (asserts! (> (len category) u0) ERR_INVALID_INPUT)
     (asserts! (> (len region) u0) ERR_INVALID_INPUT)
+    (asserts! (> (len language) u0) ERR_INVALID_INPUT)
+    (asserts! (> audience-size u0) ERR_INVALID_INPUT)
 
     (map-set publisher-profiles
       { publisher: tx-sender }

--- a/contracts/audience-selector.clar
+++ b/contracts/audience-selector.clar
@@ -18,6 +18,8 @@
 (define-constant ERR_INVALID_INPUT (err u803))
 (define-constant ERR_SEGMENT_FULL (err u804))
 (define-constant ERR_CAMPAIGN_MISMATCH (err u805))
+(define-constant ERR_EMPTY_TAG (err u806))
+(define-constant ERR_PUBLISHER_NOT_FOUND (err u807))
 
 ;; Limits
 (define-constant MAX_TAGS_PER_SEGMENT u10)

--- a/contracts/audience-selector.clar
+++ b/contracts/audience-selector.clar
@@ -329,6 +329,8 @@
     (asserts! (is-admin) ERR_UNAUTHORIZED)
     (asserts! (<= score u100) ERR_INVALID_INPUT)
     (asserts! (is-some (map-get? segments { segment-id: segment-id })) ERR_NOT_FOUND)
+    ;; Verify publisher has a registered profile
+    (asserts! (is-some (map-get? publisher-profiles { publisher: publisher })) ERR_NOT_FOUND)
 
     (map-set match-scores
       { segment-id: segment-id, publisher: publisher }

--- a/contracts/audience-selector.clar
+++ b/contracts/audience-selector.clar
@@ -236,15 +236,26 @@
 
     (map-set publisher-profiles
       { publisher: tx-sender }
-      {
-        category: category,
-        region: region,
-        language: language,
-        audience-size: audience-size,
-        tag-count: (if is-new u0 (get tag-count (unwrap-panic existing))),
-        registered-at: (if is-new stacks-block-height (get registered-at (unwrap-panic existing))),
-        last-updated: stacks-block-height
-      }
+      (match existing
+        prev-profile {
+          category: category,
+          region: region,
+          language: language,
+          audience-size: audience-size,
+          tag-count: (get tag-count prev-profile),
+          registered-at: (get registered-at prev-profile),
+          last-updated: stacks-block-height
+        }
+        {
+          category: category,
+          region: region,
+          language: language,
+          audience-size: audience-size,
+          tag-count: u0,
+          registered-at: stacks-block-height,
+          last-updated: stacks-block-height
+        }
+      )
     )
 
     (if is-new

--- a/contracts/audience-selector.clar
+++ b/contracts/audience-selector.clar
@@ -302,6 +302,14 @@
       (merge profile { tag-count: (+ current-tags u1), last-updated: stacks-block-height })
     )
 
+    (print {
+      event: "publisher-tag-added",
+      publisher: tx-sender,
+      tag: tag,
+      tag-index: current-tags,
+      timestamp: stacks-block-time
+    })
+
     (ok true)
   )
 )

--- a/contracts/audience-selector.clar
+++ b/contracts/audience-selector.clar
@@ -24,6 +24,7 @@
 (define-constant MAX_SEGMENTS_PER_CAMPAIGN u5)
 (define-constant MAX_TAG_LENGTH u32)
 (define-constant MAX_SEGMENT_NAME_LENGTH u64)
+(define-constant MAX_PUBLISHER_TAGS u10)
 
 ;; ============================================================
 ;; Data Variables
@@ -292,7 +293,7 @@
     (current-tags (get tag-count profile))
   )
     (asserts! (> (len tag) u0) ERR_INVALID_INPUT)
-    (asserts! (< current-tags MAX_TAGS_PER_SEGMENT) ERR_SEGMENT_FULL)
+    (asserts! (< current-tags MAX_PUBLISHER_TAGS) ERR_SEGMENT_FULL)
 
     (map-set publisher-tags
       { publisher: tx-sender, tag-index: current-tags }

--- a/contracts/audience-selector.clar
+++ b/contracts/audience-selector.clar
@@ -335,6 +335,14 @@
       { score: score, computed-at: stacks-block-height }
     )
 
+    (print {
+      event: "match-score-recorded",
+      segment-id: segment-id,
+      publisher: publisher,
+      score: score,
+      timestamp: stacks-block-time
+    })
+
     (ok true)
   )
 )

--- a/contracts/cash-distributor.clar
+++ b/contracts/cash-distributor.clar
@@ -170,7 +170,7 @@
     (net (- amount fee))
     (totals (get-publisher-totals publisher))
   )
-    (asserts! (or (is-contract-owner) (is-eq contract-caller CONTRACT_OWNER)) ERR_NOT_AUTHORIZED)
+    (asserts! (is-contract-owner) ERR_NOT_AUTHORIZED)
     (asserts! (> amount u0) ERR_INVALID_AMOUNT)
 
     ;; Update per-campaign earnings

--- a/contracts/cash-distributor.clar
+++ b/contracts/cash-distributor.clar
@@ -225,16 +225,13 @@
     (asserts! (> claimable u0) ERR_NO_EARNINGS)
     (asserts! (>= claimable MIN_PAYOUT_AMOUNT) ERR_MIN_PAYOUT_NOT_MET)
 
-    ;; Clarity 4: CONTRACT_OWNER admin wallet issues the payout transfer
-    (try! (stx-transfer? claimable tx-sender publisher))
-
-    ;; Update earnings claimed amount
+    ;; Update earnings claimed amount BEFORE transfer to prevent reentrancy
     (map-set publisher-earnings
       { campaign-id: campaign-id, publisher: publisher }
       (merge earnings { claimed: (+ (get claimed earnings) claimable) })
     )
 
-    ;; Create payout record
+    ;; Create payout record BEFORE transfer
     (map-set payouts
       { payout-id: payout-id }
       {
@@ -248,7 +245,7 @@
       }
     )
 
-    ;; Update publisher totals
+    ;; Update publisher totals BEFORE transfer
     (map-set publisher-totals
       { publisher: publisher }
       (merge totals {
@@ -259,6 +256,10 @@
 
     (var-set total-distributed (+ (var-get total-distributed) claimable))
     (var-set total-payouts-processed (+ (var-get total-payouts-processed) u1))
+
+    ;; Clarity 4: CONTRACT_OWNER admin wallet issues the payout transfer
+    ;; Transfer AFTER all state updates to prevent reentrancy attacks
+    (try! (stx-transfer? claimable tx-sender publisher))
 
     (print {
       event: "payout-claimed",

--- a/contracts/cash-distributor.clar
+++ b/contracts/cash-distributor.clar
@@ -19,6 +19,7 @@
 (define-constant ERR_INVALID_AMOUNT (err u605))
 (define-constant ERR_PAYOUT_PAUSED (err u606))
 (define-constant ERR_MIN_PAYOUT_NOT_MET (err u607))
+(define-constant ERR_SELF_PAYOUT (err u608))
 
 ;; Minimum payout threshold: 0.01 STX
 (define-constant MIN_PAYOUT_AMOUNT u10000)

--- a/contracts/cash-distributor.clar
+++ b/contracts/cash-distributor.clar
@@ -259,7 +259,9 @@
 
     ;; Clarity 4: CONTRACT_OWNER admin wallet issues the payout transfer
     ;; Transfer AFTER all state updates to prevent reentrancy attacks
-    (try! (stx-transfer? claimable tx-sender publisher))
+    ;; Note: tx-sender here should be CONTRACT_OWNER calling on behalf of the system
+    ;; The publisher claims, but the actual STX comes from the admin escrow wallet
+    (try! (stx-transfer? claimable CONTRACT_OWNER publisher))
 
     (print {
       event: "payout-claimed",

--- a/contracts/cash-distributor.clar
+++ b/contracts/cash-distributor.clar
@@ -172,6 +172,8 @@
   )
     (asserts! (is-contract-owner) ERR_NOT_AUTHORIZED)
     (asserts! (> amount u0) ERR_INVALID_AMOUNT)
+    ;; Prevent recording earnings for the contract owner itself
+    (asserts! (not (is-eq publisher CONTRACT_OWNER)) ERR_INVALID_AMOUNT)
 
     ;; Update per-campaign earnings
     (map-set publisher-earnings

--- a/contracts/funds-keeper.clar
+++ b/contracts/funds-keeper.clar
@@ -19,6 +19,7 @@
 (define-constant ERR_INVALID_AMOUNT (err u505))
 (define-constant ERR_INVALID_RECIPIENT (err u506))
 (define-constant ERR_COOLDOWN_ACTIVE (err u507))
+(define-constant ERR_ZERO_CAMPAIGN_ID (err u508))
 
 ;; Escrow status
 (define-constant STATUS_ACTIVE u1)

--- a/contracts/funds-keeper.clar
+++ b/contracts/funds-keeper.clar
@@ -117,7 +117,7 @@
 ;; Create a new escrow for a campaign (called during campaign creation)
 (define-public (create-escrow (campaign-id uint) (advertiser principal) (amount uint))
   (begin
-    (asserts! (or (is-contract-owner) (is-eq contract-caller CONTRACT_OWNER)) ERR_NOT_AUTHORIZED)
+    (asserts! (is-contract-owner) ERR_NOT_AUTHORIZED)
     (asserts! (is-none (map-get? escrows { campaign-id: campaign-id })) ERR_ALREADY_EXISTS)
     (asserts! (>= amount MIN_ESCROW_AMOUNT) ERR_INVALID_AMOUNT)
 
@@ -158,7 +158,7 @@
     (available (- (get deposited escrow) (+ (get released escrow) (get refunded escrow))))
     (pub-release (get-publisher-release campaign-id publisher))
   )
-    (asserts! (or (is-contract-owner) (is-eq contract-caller CONTRACT_OWNER)) ERR_NOT_AUTHORIZED)
+    (asserts! (is-contract-owner) ERR_NOT_AUTHORIZED)
     (asserts! (is-eq (get status escrow) STATUS_ACTIVE) ERR_ESCROW_CLOSED)
     (asserts! (> amount u0) ERR_INVALID_AMOUNT)
     (asserts! (<= amount available) ERR_INSUFFICIENT_BALANCE)
@@ -213,7 +213,7 @@
     (escrow (unwrap! (map-get? escrows { campaign-id: campaign-id }) ERR_ESCROW_NOT_FOUND))
     (remaining (- (get deposited escrow) (+ (get released escrow) (get refunded escrow))))
   )
-    (asserts! (or (is-contract-owner) (is-eq contract-caller CONTRACT_OWNER)) ERR_NOT_AUTHORIZED)
+    (asserts! (is-contract-owner) ERR_NOT_AUTHORIZED)
     (asserts! (is-eq (get status escrow) STATUS_ACTIVE) ERR_ESCROW_CLOSED)
 
     (if (> remaining u0)
@@ -260,7 +260,7 @@
   (let (
     (escrow (unwrap! (map-get? escrows { campaign-id: campaign-id }) ERR_ESCROW_NOT_FOUND))
   )
-    (asserts! (or (is-contract-owner) (is-eq contract-caller CONTRACT_OWNER)) ERR_NOT_AUTHORIZED)
+    (asserts! (is-contract-owner) ERR_NOT_AUTHORIZED)
     (asserts! (is-eq (get status escrow) STATUS_ACTIVE) ERR_ESCROW_CLOSED)
 
     (map-set escrows

--- a/contracts/funds-keeper.clar
+++ b/contracts/funds-keeper.clar
@@ -218,9 +218,7 @@
 
     (if (> remaining u0)
       (begin
-        ;; Clarity 4: CONTRACT_OWNER admin wallet issues the refund transfer
-        (try! (stx-transfer? remaining tx-sender (get advertiser escrow)))
-
+        ;; Update escrow state BEFORE transfer to prevent reentrancy
         (map-set escrows
           { campaign-id: campaign-id }
           (merge escrow {
@@ -230,6 +228,10 @@
         )
 
         (var-set total-refunded (+ (var-get total-refunded) remaining))
+
+        ;; Clarity 4: CONTRACT_OWNER admin wallet issues the refund transfer
+        ;; Transfer AFTER state updates to prevent reentrancy attacks
+        (try! (stx-transfer? remaining tx-sender (get advertiser escrow)))
 
         (print {
           event: "funds-refunded",

--- a/contracts/funds-keeper.clar
+++ b/contracts/funds-keeper.clar
@@ -170,10 +170,7 @@
       (>= (- stacks-block-height (get last-release-block escrow)) WITHDRAWAL_COOLDOWN)
     ) ERR_COOLDOWN_ACTIVE)
 
-    ;; Clarity 4: CONTRACT_OWNER admin wallet issues the transfer
-    (try! (stx-transfer? amount tx-sender publisher))
-
-    ;; Update escrow
+    ;; Update escrow state BEFORE transfer to prevent reentrancy
     (map-set escrows
       { campaign-id: campaign-id }
       (merge escrow {
@@ -182,7 +179,7 @@
       })
     )
 
-    ;; Update publisher release record
+    ;; Update publisher release record BEFORE transfer
     (map-set publisher-releases
       { campaign-id: campaign-id, publisher: publisher }
       {
@@ -193,6 +190,10 @@
     )
 
     (var-set total-released (+ (var-get total-released) amount))
+
+    ;; Clarity 4: CONTRACT_OWNER admin wallet issues the transfer
+    ;; Transfer AFTER state updates to prevent reentrancy attacks
+    (try! (stx-transfer? amount tx-sender publisher))
 
     (print {
       event: "funds-released",

--- a/contracts/partner-hub.clar
+++ b/contracts/partner-hub.clar
@@ -391,6 +391,31 @@
 ;; Read-Only Functions
 ;; ============================================================
 
+;; Deactivate a campaign enrollment within a partnership
+(define-public (deactivate-campaign-enrollment (partnership-id uint) (campaign-id uint))
+  (let (
+    (enrollment (unwrap! (map-get? partnership-campaigns { partnership-id: partnership-id, campaign-id: campaign-id }) ERR_NOT_FOUND))
+    (partnership (unwrap! (map-get? partnerships { partnership-id: partnership-id }) ERR_NOT_FOUND))
+  )
+    (asserts! (or (is-eq tx-sender (get advertiser partnership)) (is-admin)) ERR_UNAUTHORIZED)
+    (asserts! (get is-active enrollment) ERR_INACTIVE)
+
+    (map-set partnership-campaigns
+      { partnership-id: partnership-id, campaign-id: campaign-id }
+      (merge enrollment { is-active: false })
+    )
+
+    (print {
+      event: "campaign-enrollment-deactivated",
+      partnership-id: partnership-id,
+      campaign-id: campaign-id,
+      timestamp: stacks-block-time
+    })
+
+    (ok true)
+  )
+)
+
 (define-read-only (get-partnership (partnership-id uint))
   (map-get? partnerships { partnership-id: partnership-id })
 )

--- a/contracts/partner-hub.clar
+++ b/contracts/partner-hub.clar
@@ -131,6 +131,7 @@
     (asserts! (is-none existing) ERR_ALREADY_EXISTS)
     (asserts! (>= commission-rate MIN_COMMISSION) ERR_INVALID_INPUT)
     (asserts! (<= commission-rate MAX_COMMISSION) ERR_INVALID_INPUT)
+    (asserts! (> (len message) u0) ERR_INVALID_INPUT)
 
     ;; Create partnership in pending state
     (map-set partnerships

--- a/contracts/partner-hub.clar
+++ b/contracts/partner-hub.clar
@@ -18,6 +18,8 @@
 (define-constant ERR_SELF_PARTNER (err u904))
 (define-constant ERR_INACTIVE (err u905))
 (define-constant ERR_WRONG_STATUS (err u906))
+(define-constant ERR_EXPIRED (err u907))
+(define-constant ERR_DUPLICATE_ENROLLMENT (err u908))
 
 ;; Partnership statuses
 (define-constant STATUS_PENDING u1)

--- a/contracts/partner-hub.clar
+++ b/contracts/partner-hub.clar
@@ -299,6 +299,8 @@
   )
     (asserts! (is-eq tx-sender (get advertiser partnership)) ERR_UNAUTHORIZED)
     (asserts! (is-eq (get status partnership) STATUS_ACTIVE) ERR_INACTIVE)
+    ;; Prevent duplicate enrollment
+    (asserts! (is-none (map-get? partnership-campaigns { partnership-id: partnership-id, campaign-id: campaign-id })) ERR_ALREADY_EXISTS)
 
     (map-set partnership-campaigns
       { partnership-id: partnership-id, campaign-id: campaign-id }

--- a/contracts/partner-hub.clar
+++ b/contracts/partner-hub.clar
@@ -277,7 +277,7 @@
       })
     )
 
-    (if was-active
+    (if (and was-active (> (var-get total-active-partnerships) u0))
       (var-set total-active-partnerships (- (var-get total-active-partnerships) u1))
       true
     )

--- a/contracts/partner-hub.clar
+++ b/contracts/partner-hub.clar
@@ -226,7 +226,11 @@
       })
     )
 
-    (var-set total-active-partnerships (- (var-get total-active-partnerships) u1))
+    ;; Guard against underflow when decrementing active count
+    (if (> (var-get total-active-partnerships) u0)
+      (var-set total-active-partnerships (- (var-get total-active-partnerships) u1))
+      true
+    )
 
     (print { event: "partnership-paused", partnership-id: partnership-id, paused-by: tx-sender, timestamp: stacks-block-time })
     (ok true)

--- a/contracts/partner-hub.clar
+++ b/contracts/partner-hub.clar
@@ -360,6 +360,15 @@
       })
     )
 
+    (print {
+      event: "partnership-activity-recorded",
+      partnership-id: partnership-id,
+      campaign-id: campaign-id,
+      views: views,
+      revenue: revenue,
+      timestamp: stacks-block-time
+    })
+
     (ok true)
   )
 )

--- a/contracts/promo-manager.clar
+++ b/contracts/promo-manager.clar
@@ -342,6 +342,17 @@
     ) ERR_CAMPAIGN_NOT_ACTIVE)
     (asserts! (> remaining u0) ERR_INVALID_BUDGET)
 
+    ;; Mark campaign spent to prevent double-refund before transfer
+    (map-set campaigns
+      { campaign-id: campaign-id }
+      (merge campaign {
+        spent: (get budget campaign),
+        last-updated: stacks-block-height,
+        last-updated-timestamp: stacks-block-time,
+      })
+    )
+
+    ;; Transfer AFTER state update to prevent reentrancy
     (try! (stx-transfer? remaining tx-sender (get advertiser campaign)))
 
     (print {

--- a/contracts/promo-manager.clar
+++ b/contracts/promo-manager.clar
@@ -23,6 +23,7 @@
 (define-constant ERR_INVALID_NAME (err u107))
 (define-constant ERR_CAMPAIGN_EXPIRED (err u108))
 (define-constant ERR_DAILY_BUDGET_EXCEEDED (err u109))
+(define-constant ERR_CONTRACT_PAUSED (err u110))
 
 ;; Minimum budget: 1 STX (1,000,000 micro-STX)
 (define-constant MIN_BUDGET u1000000)

--- a/contracts/promo-manager.clar
+++ b/contracts/promo-manager.clar
@@ -460,7 +460,11 @@
         })
       )
 
-      (var-set total-stx-locked (- (var-get total-stx-locked) remaining))
+      ;; Underflow protection
+      (if (>= (var-get total-stx-locked) remaining)
+        (var-set total-stx-locked (- (var-get total-stx-locked) remaining))
+        (var-set total-stx-locked u0)
+      )
 
       (print {
         event: "campaign-completed",

--- a/contracts/promo-manager.clar
+++ b/contracts/promo-manager.clar
@@ -370,7 +370,7 @@
 (define-public (record-spend (campaign-id uint) (amount uint))
   (let ((campaign (unwrap! (map-get? campaigns { campaign-id: campaign-id }) ERR_CAMPAIGN_NOT_FOUND)))
     ;; Only contract owner or authorized contracts can record spending
-    (asserts! (or (is-contract-owner) (is-eq contract-caller CONTRACT_OWNER)) ERR_NOT_AUTHORIZED)
+    (asserts! (is-contract-owner) ERR_NOT_AUTHORIZED)
     (asserts! (is-eq (get status campaign) STATUS_ACTIVE) ERR_CAMPAIGN_NOT_ACTIVE)
     (asserts! (<= (+ (get spent campaign) amount) (get budget campaign)) ERR_BUDGET_EXCEEDED)
 

--- a/contracts/promo-manager.clar
+++ b/contracts/promo-manager.clar
@@ -372,9 +372,12 @@
 ;; Record spending against a campaign (called by stats-tracker)
 (define-public (record-spend (campaign-id uint) (amount uint))
   (let ((campaign (unwrap! (map-get? campaigns { campaign-id: campaign-id }) ERR_CAMPAIGN_NOT_FOUND)))
+    ;; Reject spend recording when contract is paused
+    (asserts! (not (var-get contract-paused)) ERR_NOT_AUTHORIZED)
     ;; Only contract owner or authorized contracts can record spending
     (asserts! (is-contract-owner) ERR_NOT_AUTHORIZED)
     (asserts! (is-eq (get status campaign) STATUS_ACTIVE) ERR_CAMPAIGN_NOT_ACTIVE)
+    (asserts! (> amount u0) ERR_INVALID_BUDGET)
     (asserts! (<= (+ (get spent campaign) amount) (get budget campaign)) ERR_BUDGET_EXCEEDED)
 
     ;; Check daily budget

--- a/contracts/promo-manager.clar
+++ b/contracts/promo-manager.clar
@@ -315,8 +315,11 @@
       })
     )
 
-    ;; Update total locked
-    (var-set total-stx-locked (- (var-get total-stx-locked) remaining))
+    ;; Update total locked with underflow protection
+    (if (>= (var-get total-stx-locked) remaining)
+      (var-set total-stx-locked (- (var-get total-stx-locked) remaining))
+      (var-set total-stx-locked u0)
+    )
 
     (print {
       event: "campaign-cancelled",

--- a/contracts/promo-manager.clar
+++ b/contracts/promo-manager.clar
@@ -378,6 +378,8 @@
     (asserts! (is-contract-owner) ERR_NOT_AUTHORIZED)
     (asserts! (is-eq (get status campaign) STATUS_ACTIVE) ERR_CAMPAIGN_NOT_ACTIVE)
     (asserts! (> amount u0) ERR_INVALID_BUDGET)
+    ;; Check campaign has not expired
+    (asserts! (<= stacks-block-height (get end-height campaign)) ERR_CAMPAIGN_EXPIRED)
     (asserts! (<= (+ (get spent campaign) amount) (get budget campaign)) ERR_BUDGET_EXCEEDED)
 
     ;; Check daily budget

--- a/contracts/stats-tracker.clar
+++ b/contracts/stats-tracker.clar
@@ -224,6 +224,7 @@
 (define-public (record-campaign-spend (campaign-id uint) (amount uint))
   (let ((analytics (get-analytics campaign-id)))
     (asserts! (is-contract-owner) ERR_NOT_AUTHORIZED)
+    (asserts! (> amount u0) ERR_INVALID_VIEWER)
 
     (map-set campaign-analytics
       { campaign-id: campaign-id }

--- a/contracts/stats-tracker.clar
+++ b/contracts/stats-tracker.clar
@@ -246,11 +246,11 @@
 
 ;; Invalidate a fraudulent view (admin only)
 ;; Decrements valid view count for anti-fraud enforcement
-(define-public (invalidate-view (campaign-id uint) (viewer principal))
+(define-public (invalidate-view (campaign-id uint) (viewer principal) (publisher principal))
   (let (
     (record (unwrap! (map-get? viewer-records { campaign-id: campaign-id, viewer: viewer }) ERR_CAMPAIGN_NOT_FOUND))
     (analytics (get-analytics campaign-id))
-    (publisher-key { campaign-id: campaign-id, publisher: tx-sender })
+    (pub-stats (get-publisher-stats campaign-id publisher))
   )
     (asserts! (is-contract-owner) ERR_NOT_AUTHORIZED)
 
@@ -260,10 +260,33 @@
       true
     )
 
+    ;; Decrement publisher valid views count
+    (if (> (get valid-views pub-stats) u0)
+      (map-set publisher-stats
+        { campaign-id: campaign-id, publisher: publisher }
+        (merge pub-stats {
+          valid-views: (- (get valid-views pub-stats) u1),
+        })
+      )
+      true
+    )
+
+    ;; Decrement campaign-level total views
+    (if (> (get total-views analytics) u0)
+      (map-set campaign-analytics
+        { campaign-id: campaign-id }
+        (merge analytics {
+          total-views: (- (get total-views analytics) u1),
+        })
+      )
+      true
+    )
+
     (print {
       event: "view-invalidated",
       campaign-id: campaign-id,
       viewer: viewer,
+      publisher: publisher,
       timestamp: stacks-block-time,
     })
 

--- a/contracts/stats-tracker.clar
+++ b/contracts/stats-tracker.clar
@@ -13,6 +13,7 @@
 (define-constant ERR_INVALID_VIEWER (err u303))
 (define-constant ERR_CAMPAIGN_INACTIVE (err u304))
 (define-constant ERR_RATE_LIMIT (err u305))
+(define-constant ERR_ZERO_AMOUNT (err u306))
 
 ;; Rate limit: max 10 views per viewer per campaign per day (~144 blocks)
 (define-constant MAX_DAILY_VIEWS_PER_VIEWER u10)
@@ -224,7 +225,7 @@
 (define-public (record-campaign-spend (campaign-id uint) (amount uint))
   (let ((analytics (get-analytics campaign-id)))
     (asserts! (is-contract-owner) ERR_NOT_AUTHORIZED)
-    (asserts! (> amount u0) ERR_INVALID_VIEWER)
+    (asserts! (> amount u0) ERR_ZERO_AMOUNT)
 
     (map-set campaign-analytics
       { campaign-id: campaign-id }

--- a/contracts/threat-detector.clar
+++ b/contracts/threat-detector.clar
@@ -327,10 +327,20 @@
     (asserts! (is-contract-owner) ERR_NOT_AUTHORIZED)
     (asserts! (not (get resolved flag)) ERR_ALREADY_FLAGGED)
 
-    ;; Mark flag as resolved
+    ;; Mark flag as resolved with resolver info
     (map-set fraud-flags
       { campaign-id: campaign-id, flag-index: flag-index }
       (merge flag { resolved: true })
+    )
+
+    ;; Update account threats for the reporter
+    (let ((reporter-threats (get-account-threats (get reporter flag))))
+      (map-set account-threats
+        { account: (get reporter flag) }
+        (merge reporter-threats {
+          total-flags-resolved: (+ (get total-flags-resolved reporter-threats) u1),
+        })
+      )
     )
 
     ;; Reduce fraud score by 10 (min 0)

--- a/contracts/threat-detector.clar
+++ b/contracts/threat-detector.clar
@@ -11,6 +11,7 @@
 (define-constant ERR_CAMPAIGN_NOT_FOUND (err u701))
 (define-constant ERR_ALREADY_FLAGGED (err u702))
 (define-constant ERR_NOT_FLAGGED (err u703))
+(define-constant ERR_NOT_BLOCKED (err u706))
 (define-constant ERR_INVALID_SCORE (err u704))
 (define-constant ERR_ACCOUNT_NOT_FOUND (err u705))
 
@@ -278,7 +279,7 @@
 (define-public (unblock-account (account principal))
   (let ((threats (get-account-threats account)))
     (asserts! (is-contract-owner) ERR_NOT_AUTHORIZED)
-    (asserts! (get is-blocked threats) ERR_NOT_FLAGGED)
+    (asserts! (get is-blocked threats) ERR_NOT_BLOCKED)
 
     (map-set account-threats
       { account: account }

--- a/contracts/threat-detector.clar
+++ b/contracts/threat-detector.clar
@@ -240,6 +240,17 @@
 
     (var-set total-flags (+ (var-get total-flags) u1))
 
+    ;; Track flag in reporter's account-threats record
+    (let ((reporter-threats (get-account-threats tx-sender)))
+      (map-set account-threats
+        { account: tx-sender }
+        (merge reporter-threats {
+          total-flags-received: (+ (get total-flags-received reporter-threats) u1),
+          last-flagged: stacks-block-height,
+        })
+      )
+    )
+
     (print {
       event: "fraud-flag-submitted",
       campaign-id: campaign-id,

--- a/contracts/threat-detector.clar
+++ b/contracts/threat-detector.clar
@@ -187,6 +187,8 @@
   )
     ;; Validate flag type (1-5)
     (asserts! (and (>= flag-type u1) (<= flag-type u5)) ERR_INVALID_SCORE)
+    ;; Validate evidence hash is not empty (all zeros)
+    (asserts! (not (is-eq evidence-hash 0x0000000000000000000000000000000000000000000000000000000000000000)) ERR_INVALID_SCORE)
 
     ;; Rate limit: check cooldown period for this reporter on this campaign
     (let ((last-flag (default-to { last-flag-block: u0 }

--- a/contracts/threat-detector.clar
+++ b/contracts/threat-detector.clar
@@ -35,6 +35,10 @@
 (define-constant THRESHOLD_HIGH u75)
 (define-constant THRESHOLD_CRITICAL u90)
 
+;; Rate limiting for flag submissions
+(define-constant FLAG_COOLDOWN_BLOCKS u12) ;; ~2 hours between flags from same reporter
+(define-constant ERR_FLAG_COOLDOWN (err u707))
+
 ;; --- Data Variables ---
 
 (define-data-var total-flags uint u0)
@@ -83,6 +87,12 @@
 (define-map campaign-flag-counts
   { campaign-id: uint }
   { count: uint }
+)
+
+;; Track last flag submission per reporter per campaign
+(define-map reporter-last-flag
+  { campaign-id: uint, reporter: principal }
+  { last-flag-block: uint }
 )
 
 ;; --- Private Functions ---
@@ -177,6 +187,21 @@
   )
     ;; Validate flag type (1-5)
     (asserts! (and (>= flag-type u1) (<= flag-type u5)) ERR_INVALID_SCORE)
+
+    ;; Rate limit: check cooldown period for this reporter on this campaign
+    (let ((last-flag (default-to { last-flag-block: u0 }
+            (map-get? reporter-last-flag { campaign-id: campaign-id, reporter: tx-sender }))))
+      (asserts! (or
+        (is-eq (get last-flag-block last-flag) u0)
+        (>= (- stacks-block-height (get last-flag-block last-flag)) FLAG_COOLDOWN_BLOCKS)
+      ) ERR_FLAG_COOLDOWN)
+    )
+
+    ;; Update reporter last flag time
+    (map-set reporter-last-flag
+      { campaign-id: campaign-id, reporter: tx-sender }
+      { last-flag-block: stacks-block-height }
+    )
 
     ;; Record the flag
     (map-set fraud-flags

--- a/contracts/threat-detector.clar
+++ b/contracts/threat-detector.clar
@@ -38,6 +38,8 @@
 ;; Rate limiting for flag submissions
 (define-constant FLAG_COOLDOWN_BLOCKS u12) ;; ~2 hours between flags from same reporter
 (define-constant ERR_FLAG_COOLDOWN (err u707))
+(define-constant ERR_SELF_FLAG (err u708))
+(define-constant ERR_EMPTY_EVIDENCE (err u709))
 
 ;; --- Data Variables ---
 

--- a/contracts/user-profiles.clar
+++ b/contracts/user-profiles.clar
@@ -214,7 +214,11 @@
 (define-public (request-verification)
   (let ((profile (unwrap! (map-get? profiles { user: tx-sender }) ERR_NOT_REGISTERED)))
     (asserts! (not (is-eq (get status profile) STATUS_SUSPENDED)) ERR_ACCOUNT_SUSPENDED)
-    (asserts! (is-eq (get verification-status profile) VERIFICATION_UNVERIFIED) ERR_ALREADY_VERIFIED)
+    (asserts! (is-eq (get status profile) STATUS_ACTIVE) ERR_ACCOUNT_SUSPENDED)
+    (asserts! (or
+      (is-eq (get verification-status profile) VERIFICATION_UNVERIFIED)
+      (is-eq (get verification-status profile) VERIFICATION_REJECTED)
+    ) ERR_ALREADY_VERIFIED)
 
     (map-set profiles
       { user: tx-sender }

--- a/contracts/user-profiles.clar
+++ b/contracts/user-profiles.clar
@@ -252,6 +252,9 @@
 ;; Increment campaign count for a user (called by promo-manager)
 (define-public (increment-campaigns (user principal))
   (let ((profile (unwrap! (map-get? profiles { user: user }) ERR_NOT_REGISTERED)))
+    ;; Only contract owner (or authorized caller contracts) can increment
+    (asserts! (is-contract-owner) ERR_NOT_AUTHORIZED)
+    (asserts! (not (is-eq (get status profile) STATUS_SUSPENDED)) ERR_ACCOUNT_SUSPENDED)
     (map-set profiles
       { user: user }
       (merge profile {
@@ -259,6 +262,8 @@
         last-active: stacks-block-height,
       })
     )
+
+    (print { event: "campaigns-incremented", user: user, timestamp: stacks-block-time })
     (ok true)
   )
 )

--- a/contracts/user-profiles.clar
+++ b/contracts/user-profiles.clar
@@ -235,9 +235,12 @@
   )
 )
 
-;; Update activity timestamp (called by other contracts)
+;; Update activity timestamp (called by other contracts or the user themselves)
 (define-public (update-activity (user principal))
   (let ((profile (unwrap! (map-get? profiles { user: user }) ERR_NOT_REGISTERED)))
+    ;; Only the user or contract owner can update activity
+    (asserts! (or (is-eq tx-sender user) (is-contract-owner)) ERR_NOT_AUTHORIZED)
+    (asserts! (not (is-eq (get status profile) STATUS_SUSPENDED)) ERR_ACCOUNT_SUSPENDED)
     (map-set profiles
       { user: user }
       (merge profile { last-active: stacks-block-height })

--- a/contracts/user-profiles.clar
+++ b/contracts/user-profiles.clar
@@ -287,7 +287,17 @@
       })
     )
 
-    (print { event: "verification-updated", user: user, status: status, timestamp: stacks-block-time })
+    (print {
+      event: "verification-updated",
+      user: user,
+      status: status,
+      expires: (if (is-eq status VERIFICATION_VERIFIED)
+        (+ stacks-block-height VERIFICATION_VALIDITY_BLOCKS)
+        u0
+      ),
+      admin: tx-sender,
+      timestamp: stacks-block-time,
+    })
     (ok true)
   )
 )

--- a/contracts/user-profiles.clar
+++ b/contracts/user-profiles.clar
@@ -14,6 +14,8 @@
 (define-constant ERR_ACCOUNT_SUSPENDED (err u205))
 (define-constant ERR_ALREADY_VERIFIED (err u206))
 (define-constant ERR_VERIFICATION_PENDING (err u207))
+(define-constant ERR_INVALID_SCORE (err u208))
+(define-constant ERR_NOT_ACTIVE (err u209))
 
 ;; Role constants
 (define-constant ROLE_ADVERTISER u1)

--- a/contracts/user-profiles.clar
+++ b/contracts/user-profiles.clar
@@ -35,6 +35,8 @@
 
 ;; Verification valid for ~30 days (4320 blocks)
 (define-constant VERIFICATION_VALIDITY_BLOCKS u4320)
+;; Maximum number of campaigns per user
+(define-constant MAX_CAMPAIGNS_PER_USER u100)
 
 ;; Maximum display name length
 (define-constant MAX_NAME_LENGTH u48)

--- a/contracts/vote-handler.clar
+++ b/contracts/vote-handler.clar
@@ -30,7 +30,8 @@
 (define-constant MAX_DESCRIPTION_LENGTH u256)
 (define-constant MIN_VOTING_PERIOD u144) ;; ~1 day
 (define-constant MAX_VOTING_PERIOD u4320) ;; ~30 days
-(define-constant QUORUM_THRESHOLD u3) ;; Minimum 3 votes for quorum
+(define-constant QUORUM_THRESHOLD u10) ;; Minimum 10 votes for quorum
+(define-constant MIN_PASSING_MARGIN u2) ;; Must win by at least 2 votes
 
 ;; --- Data Variables ---
 

--- a/contracts/vote-handler.clar
+++ b/contracts/vote-handler.clar
@@ -205,6 +205,8 @@
   (let (
     (proposal (unwrap! (map-get? proposals { proposal-id: proposal-id }) ERR_PROPOSAL_NOT_FOUND))
   )
+    ;; Governance must not be paused
+    (asserts! (not (var-get governance-paused)) ERR_NOT_AUTHORIZED)
     ;; Voting must be open
     (asserts! (is-eq (get status proposal) STATUS_ACTIVE) ERR_VOTING_CLOSED)
     (asserts! (<= stacks-block-height (get end-height proposal)) ERR_VOTING_CLOSED)

--- a/contracts/vote-handler.clar
+++ b/contracts/vote-handler.clar
@@ -258,6 +258,7 @@
       (new-status (if (and
         (>= (get total-voters proposal) QUORUM_THRESHOLD)
         (> (get votes-for proposal) (get votes-against proposal))
+        (>= (- (get votes-for proposal) (get votes-against proposal)) MIN_PASSING_MARGIN)
       )
         STATUS_PASSED
         STATUS_REJECTED

--- a/contracts/vote-handler.clar
+++ b/contracts/vote-handler.clar
@@ -21,6 +21,7 @@
 
 ;; Maximum active proposals per proposer to prevent spam
 (define-constant MAX_ACTIVE_PROPOSALS_PER_USER u5)
+(define-constant ERR_VOTING_NOT_STARTED (err u411))
 
 ;; Proposal status
 (define-constant STATUS_ACTIVE u1)

--- a/contracts/vote-handler.clar
+++ b/contracts/vote-handler.clar
@@ -281,6 +281,8 @@
         status: new-status,
         votes-for: (get votes-for proposal),
         votes-against: (get votes-against proposal),
+        total-voters: (get total-voters proposal),
+        quorum-met: (>= (get total-voters proposal) QUORUM_THRESHOLD),
         timestamp: stacks-block-time,
       })
 

--- a/contracts/vote-handler.clar
+++ b/contracts/vote-handler.clar
@@ -17,6 +17,10 @@
 (define-constant ERR_PROPOSAL_ALREADY_EXECUTED (err u407))
 (define-constant ERR_QUORUM_NOT_MET (err u408))
 (define-constant ERR_NOT_REGISTERED (err u409))
+(define-constant ERR_PROPOSAL_LIMIT_REACHED (err u410))
+
+;; Maximum active proposals per proposer to prevent spam
+(define-constant MAX_ACTIVE_PROPOSALS_PER_USER u5)
 
 ;; Proposal status
 (define-constant STATUS_ACTIVE u1)

--- a/src/hooks/use-mempool.ts
+++ b/src/hooks/use-mempool.ts
@@ -11,11 +11,14 @@ export function useMempoolTransactions(
   address: string | undefined | null,
   limit = 10,
 ) {
+  const validAddress = address && address.length > 0 ? address : undefined;
+  const clampedLimit = Math.min(Math.max(1, limit), 50);
+
   return useApiQuery(
-    ['mempool', address, limit],
-    () => fetchMempoolTransactions(address!, limit),
+    ['mempool', validAddress, clampedLimit],
+    () => fetchMempoolTransactions(validAddress!, clampedLimit),
     {
-      enabled: !!address,
+      enabled: !!validAddress,
       staleTime: 10_000,
       refetchInterval: 15_000,
       refetchIntervalInBackground: false,

--- a/src/hooks/use-tx-status.ts
+++ b/src/hooks/use-tx-status.ts
@@ -5,7 +5,7 @@ import { fetchTransaction, type ApiTransaction } from '@/lib/stacks-api';
 import { CURRENT_NETWORK } from '@/lib/stacks-config';
 
 /** Transaction status as observed from the API. */
-export type TxStatus = 'pending' | 'success' | 'abort_by_response' | 'abort_by_post_condition' | 'unknown';
+export type TxStatus = 'pending' | 'success' | 'abort_by_response' | 'abort_by_post_condition' | 'dropped' | 'unknown';
 
 /** Parsed transaction status info. */
 export interface TxStatusInfo {
@@ -24,6 +24,7 @@ function normalizeStatus(apiStatus: string): TxStatus {
   if (apiStatus === 'pending') return 'pending';
   if (apiStatus === 'abort_by_response') return 'abort_by_response';
   if (apiStatus === 'abort_by_post_condition') return 'abort_by_post_condition';
+  if (apiStatus === 'dropped' || apiStatus === 'dropped_replace_by_fee' || apiStatus === 'dropped_replace_across_fork' || apiStatus === 'dropped_too_expensive' || apiStatus === 'dropped_stale_garbage_collect') return 'dropped';
   return 'unknown';
 }
 
@@ -66,7 +67,7 @@ export function useTxStatus(txId: string | undefined, pollInterval = 5000) {
 
       const tx = result.data;
       const status = normalizeStatus(tx.tx_status);
-      const isFinalized = status !== 'pending' && status !== 'unknown';
+      const isFinalized = status !== 'pending' && status !== 'unknown' && status !== 'dropped';
 
       return {
         txId,
@@ -105,7 +106,7 @@ export function useBatchTxStatus(txIds: string[]) {
       }
       const tx = result.data;
       const status = normalizeStatus(tx.tx_status);
-      const isFinalized = status !== 'pending' && status !== 'unknown';
+      const isFinalized = status !== 'pending' && status !== 'unknown' && status !== 'dropped';
       return { txId, status, blockHeight: isFinalized ? tx.block_height : null, raw: tx, isFinalized };
     },
   }));
@@ -124,7 +125,7 @@ export function useBatchTxStatus(txIds: string[]) {
           }
           const tx = result.data;
           const status = normalizeStatus(tx.tx_status);
-          const isFinalized = status !== 'pending' && status !== 'unknown';
+          const isFinalized = status !== 'pending' && status !== 'unknown' && status !== 'dropped';
           statuses[txId] = { txId, status, blockHeight: isFinalized ? tx.block_height : null, raw: tx, isFinalized };
         }),
       );

--- a/src/lib/address-validation.ts
+++ b/src/lib/address-validation.ts
@@ -62,9 +62,9 @@ export function isValidContractId(contractId: string): boolean {
 
   if (!isValidStacksAddress(address)) return false;
 
-  // Contract names: 1-128 chars, alphanumeric plus hyphens
-  if (!contractName || contractName.length > 128) return false;
-  if (!/^[a-zA-Z][a-zA-Z0-9-]*$/.test(contractName)) return false;
+  // Contract names: 1-128 chars, start with alpha, alphanumeric/hyphens/underscores
+  if (!contractName || contractName.length === 0 || contractName.length > 128) return false;
+  if (!/^[a-zA-Z][a-zA-Z0-9_-]*$/.test(contractName)) return false;
 
   return true;
 }

--- a/src/lib/appkit-config.ts
+++ b/src/lib/appkit-config.ts
@@ -9,8 +9,17 @@ import { CURRENT_NETWORK, APP_DETAILS } from './stacks-config';
  * WalletConnect Project ID
  * Get yours at https://cloud.reown.com/
  */
-export const WALLETCONNECT_PROJECT_ID =
-  process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || 'demo-project-id';
+const envProjectId = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID;
+
+if (!envProjectId && typeof console !== 'undefined') {
+  console.error(
+    '[AdStack] NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID is not set. ' +
+    'WalletConnect will not work without a valid project ID. ' +
+    'Get one at https://cloud.reown.com/'
+  );
+}
+
+export const WALLETCONNECT_PROJECT_ID = envProjectId || '';
 
 /**
  * Stacks Chain Configuration for Reown AppKit

--- a/src/lib/clarity-converters.ts
+++ b/src/lib/clarity-converters.ts
@@ -54,10 +54,15 @@ export function toBoolCV(value: boolean): BoolCV {
  * Create a Clarity string-ascii value.
  * Validates that the string only contains ASCII characters.
  */
-export function toStringAsciiCV(value: string): StringAsciiCV {
+const MAX_ASCII_STRING_LENGTH = 128;
+
+export function toStringAsciiCV(value: string, maxLength = MAX_ASCII_STRING_LENGTH): StringAsciiCV {
+  if (value.length > maxLength) {
+    throw new RangeError(`ASCII string length ${value.length} exceeds max ${maxLength}`);
+  }
   for (let i = 0; i < value.length; i++) {
     if (value.charCodeAt(i) > 127) {
-      throw new RangeError(`Non-ASCII character at position ${i}: "${value[i]}"`);
+      throw new RangeError(`Non-ASCII character at position ${i}: "${value[i]}" (code ${value.charCodeAt(i)})`);
     }
   }
   return { type: 'string-ascii', value };

--- a/src/lib/clarity-converters.ts
+++ b/src/lib/clarity-converters.ts
@@ -71,7 +71,12 @@ export function toStringAsciiCV(value: string, maxLength = MAX_ASCII_STRING_LENG
 /**
  * Create a Clarity string-utf8 value.
  */
-export function toStringUtf8CV(value: string): StringUtf8CV {
+const MAX_UTF8_STRING_LENGTH = 256;
+
+export function toStringUtf8CV(value: string, maxLength = MAX_UTF8_STRING_LENGTH): StringUtf8CV {
+  if (value.length > maxLength) {
+    throw new RangeError(`UTF-8 string length ${value.length} exceeds max ${maxLength}`);
+  }
   return { type: 'string-utf8', value };
 }
 

--- a/src/lib/clarity-converters.ts
+++ b/src/lib/clarity-converters.ts
@@ -107,7 +107,12 @@ export function toPrincipalCV(address: string): PrincipalCV {
 /**
  * Create a Clarity list value from an array of Clarity values.
  */
+const MAX_CLARITY_LIST_SIZE = 2000;
+
 export function toListCV(items: ClarityValue[]): ListCV {
+  if (items.length > MAX_CLARITY_LIST_SIZE) {
+    throw new RangeError(`List size ${items.length} exceeds Clarity maximum of ${MAX_CLARITY_LIST_SIZE}`);
+  }
   return { type: 'list', value: items };
 }
 

--- a/src/lib/clarity-converters.ts
+++ b/src/lib/clarity-converters.ts
@@ -32,8 +32,14 @@ export function toUIntCV(value: number | bigint): UIntCV {
 /**
  * Create a Clarity int value.
  */
+const INT128_MIN = -(1n << 127n);
+const INT128_MAX = (1n << 127n) - 1n;
+
 export function toIntCV(value: number | bigint): IntCV {
   const n = typeof value === 'number' ? BigInt(Math.floor(value)) : value;
+  if (n < INT128_MIN || n > INT128_MAX) {
+    throw new RangeError(`Int value ${n} is outside int128 range [${INT128_MIN}, ${INT128_MAX}]`);
+  }
   return { type: 'int', value: n };
 }
 

--- a/src/lib/clarity-converters.ts
+++ b/src/lib/clarity-converters.ts
@@ -20,9 +20,12 @@ import type {
  * Create a Clarity uint value.
  * @param value - Non-negative integer or bigint
  */
+const UINT128_MAX = (1n << 128n) - 1n;
+
 export function toUIntCV(value: number | bigint): UIntCV {
   const n = typeof value === 'number' ? BigInt(Math.floor(value)) : value;
   if (n < 0n) throw new RangeError('UInt cannot be negative');
+  if (n > UINT128_MAX) throw new RangeError(`UInt value ${n} exceeds uint128 max (${UINT128_MAX})`);
   return { type: 'uint', value: n };
 }
 

--- a/src/lib/clarity-converters.ts
+++ b/src/lib/clarity-converters.ts
@@ -74,13 +74,33 @@ export function toStringUtf8CV(value: string): StringUtf8CV {
  * Create a Clarity principal value from an address string.
  * Supports both standard principals (SP...) and contract principals (SP...contract-name).
  */
+const PRINCIPAL_PATTERN = /^S[PM][A-Z0-9]{1,38}$/;
+const CONTRACT_NAME_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]{0,127}$/;
+
 export function toPrincipalCV(address: string): PrincipalCV {
+  if (!address || address.length === 0) {
+    throw new Error('toPrincipalCV: address is required');
+  }
+
   if (address.includes('.')) {
     const parts = address.split('.', 2);
     const addr = parts[0] ?? '';
     const contractName = parts[1] ?? '';
+
+    if (!PRINCIPAL_PATTERN.test(addr)) {
+      throw new Error(`toPrincipalCV: invalid standard principal format: ${addr}`);
+    }
+    if (!CONTRACT_NAME_PATTERN.test(contractName)) {
+      throw new Error(`toPrincipalCV: invalid contract name format: ${contractName}`);
+    }
+
     return { type: 'principal', value: { address: addr, contractName } };
   }
+
+  if (!PRINCIPAL_PATTERN.test(address)) {
+    throw new Error(`toPrincipalCV: invalid principal format: ${address}`);
+  }
+
   return { type: 'principal', value: { address } };
 }
 

--- a/src/lib/contract-calls.ts
+++ b/src/lib/contract-calls.ts
@@ -418,6 +418,9 @@ export function buildReadUserCounts() {
  * Build contract call for updating display name.
  */
 export function buildUpdateDisplayName(newName: string) {
+  if (!newName || newName.length === 0) throw new Error('buildUpdateDisplayName: newName is required');
+  if (newName.length > 48) throw new Error('buildUpdateDisplayName: newName exceeds max length (48)');
+
   return {
     contractAddress: CONTRACT_ADDRESS,
     contractName: CONTRACTS.USER_PROFILES,

--- a/src/lib/contract-calls.ts
+++ b/src/lib/contract-calls.ts
@@ -485,12 +485,12 @@ export function buildRecordCampaignSpend(campaignId: number, amount: number) {
  * Build contract call to invalidate a fraudulent view.
  * Admin only - decrements valid view counts for anti-fraud.
  */
-export function buildInvalidateView(campaignId: number, viewerAddress: string) {
+export function buildInvalidateView(campaignId: number, viewerAddress: string, publisherAddress: string) {
   return {
     contractAddress: CONTRACT_ADDRESS,
     contractName: CONTRACTS.STATS_TRACKER,
     functionName: 'invalidate-view',
-    functionArgs: [toUIntCV(campaignId), toPrincipalCV(viewerAddress)],
+    functionArgs: [toUIntCV(campaignId), toPrincipalCV(viewerAddress), toPrincipalCV(publisherAddress)],
     postConditionMode: PC_MODE.DENY,
     postConditions: [],
   };

--- a/src/lib/contract-calls.ts
+++ b/src/lib/contract-calls.ts
@@ -780,6 +780,9 @@ export function buildSetPublisherProfile(
  * Build contract call to add a tag to the publisher's profile.
  */
 export function buildAddPublisherTag(tag: string) {
+  if (!tag || tag.length === 0) throw new Error('buildAddPublisherTag: tag is required');
+  if (tag.length > 32) throw new Error('buildAddPublisherTag: tag exceeds max length (32)');
+
   return {
     contractAddress: CONTRACT_ADDRESS,
     contractName: CONTRACTS.AUDIENCE_SELECTOR,

--- a/src/lib/contract-calls.ts
+++ b/src/lib/contract-calls.ts
@@ -38,6 +38,12 @@ export function buildCreateCampaign(
   senderAddress: string,
   params: CreateCampaignParams,
 ) {
+  if (!senderAddress) throw new Error('buildCreateCampaign: senderAddress is required');
+  if (!params.name || params.name.length === 0) throw new Error('buildCreateCampaign: name is required');
+  if (Number(params.budget) <= 0) throw new Error('buildCreateCampaign: budget must be positive');
+  if (Number(params.dailyBudget) <= 0) throw new Error('buildCreateCampaign: dailyBudget must be positive');
+  if (Number(params.dailyBudget) > Number(params.budget)) throw new Error('buildCreateCampaign: dailyBudget cannot exceed total budget');
+
   const budgetMicro = stxToMicroStx(Number(params.budget));
   const dailyMicro = stxToMicroStx(Number(params.dailyBudget));
 

--- a/src/lib/contract-calls.ts
+++ b/src/lib/contract-calls.ts
@@ -614,6 +614,10 @@ export function buildRecordEarnings(
   publisherAddress: string,
   amount: number,
 ) {
+  if (campaignId < 0) throw new Error('buildRecordEarnings: campaignId must be non-negative');
+  if (!publisherAddress) throw new Error('buildRecordEarnings: publisherAddress is required');
+  if (amount <= 0) throw new Error('buildRecordEarnings: amount must be positive');
+
   return {
     contractAddress: CONTRACT_ADDRESS,
     contractName: CONTRACTS.CASH_DISTRIBUTOR,

--- a/src/lib/contract-calls.ts
+++ b/src/lib/contract-calls.ts
@@ -719,6 +719,10 @@ export function buildCreateSegment(
  * Build contract call to add a tag to an audience segment.
  */
 export function buildAddSegmentTag(segmentId: number, tag: string) {
+  if (segmentId < 0) throw new Error('buildAddSegmentTag: segmentId must be non-negative');
+  if (!tag || tag.length === 0) throw new Error('buildAddSegmentTag: tag is required');
+  if (tag.length > 32) throw new Error('buildAddSegmentTag: tag exceeds max length (32)');
+
   return {
     contractAddress: CONTRACT_ADDRESS,
     contractName: CONTRACTS.AUDIENCE_SELECTOR,

--- a/src/lib/contract-calls.ts
+++ b/src/lib/contract-calls.ts
@@ -98,9 +98,12 @@ export function buildResumeCampaign(campaignId: number) {
  * Calls user-profiles.register with role and display name.
  */
 export function buildRegisterUser(params: RegisterUserParams) {
+  if (!params.displayName || params.displayName.length === 0) throw new Error('buildRegisterUser: displayName is required');
+  if (params.displayName.length > 48) throw new Error('buildRegisterUser: displayName exceeds max length (48)');
+
   const roleUint = ROLE_TO_UINT[params.role];
   if (roleUint === undefined) {
-    throw new Error(`Invalid role: ${params.role}`);
+    throw new Error(`Invalid role: ${params.role}. Valid roles: ${Object.keys(ROLE_TO_UINT).join(', ')}`);
   }
 
   return {

--- a/src/lib/contract-calls.ts
+++ b/src/lib/contract-calls.ts
@@ -820,6 +820,10 @@ export function buildProposePartnership(
   commissionRate: number,
   message: string,
 ) {
+  if (!publisherAddress) throw new Error('buildProposePartnership: publisherAddress is required');
+  if (commissionRate < 100 || commissionRate > 5000) throw new Error('buildProposePartnership: commissionRate must be between 100-5000 bps');
+  if (!message || message.length === 0) throw new Error('buildProposePartnership: message is required');
+
   return {
     contractAddress: CONTRACT_ADDRESS,
     contractName: CONTRACTS.PARTNER_HUB,

--- a/src/lib/contract-calls.ts
+++ b/src/lib/contract-calls.ts
@@ -495,6 +495,9 @@ export function buildReadTotalViews() {
  * Admin only - called to sync spend data from promo-manager.
  */
 export function buildRecordCampaignSpend(campaignId: number, amount: number) {
+  if (campaignId < 0) throw new Error('buildRecordCampaignSpend: campaignId must be non-negative');
+  if (amount <= 0) throw new Error('buildRecordCampaignSpend: amount must be positive');
+
   return {
     contractAddress: CONTRACT_ADDRESS,
     contractName: CONTRACTS.STATS_TRACKER,

--- a/src/lib/contract-calls.ts
+++ b/src/lib/contract-calls.ts
@@ -213,6 +213,12 @@ export function buildSubmitView(
  * Calls vote-handler.create-proposal with title, description, duration.
  */
 export function buildCreateProposal(params: CreateProposalParams) {
+  if (!params.title || params.title.length === 0) throw new Error('buildCreateProposal: title is required');
+  if (params.title.length > 64) throw new Error('buildCreateProposal: title exceeds max length (64)');
+  if (!params.description || params.description.length === 0) throw new Error('buildCreateProposal: description is required');
+  if (params.description.length > 256) throw new Error('buildCreateProposal: description exceeds max length (256)');
+  if (params.duration <= 0) throw new Error('buildCreateProposal: duration must be positive');
+
   const durationBlocks = Math.ceil(
     params.duration / BLOCK_TIME.SECONDS_PER_BLOCK,
   );

--- a/src/lib/contract-calls.ts
+++ b/src/lib/contract-calls.ts
@@ -168,6 +168,9 @@ export function buildClaimPayout(
   campaignId: number,
   maxPayoutSTX: number,
 ) {
+  if (campaignId < 0) throw new Error('buildClaimPayout: campaignId must be non-negative');
+  if (maxPayoutSTX <= 0) throw new Error('buildClaimPayout: maxPayoutSTX must be positive');
+
   return {
     contractAddress: CONTRACT_ADDRESS,
     contractName: CONTRACTS.CASH_DISTRIBUTOR,

--- a/src/lib/contract-calls.ts
+++ b/src/lib/contract-calls.ts
@@ -742,6 +742,11 @@ export function buildSetPublisherProfile(
   language: string,
   audienceSize: number,
 ) {
+  if (!category || category.length === 0) throw new Error('buildSetPublisherProfile: category is required');
+  if (!region || region.length === 0) throw new Error('buildSetPublisherProfile: region is required');
+  if (!language || language.length === 0) throw new Error('buildSetPublisherProfile: language is required');
+  if (audienceSize <= 0) throw new Error('buildSetPublisherProfile: audienceSize must be positive');
+
   return {
     contractAddress: CONTRACT_ADDRESS,
     contractName: CONTRACTS.AUDIENCE_SELECTOR,

--- a/src/lib/contract-calls.ts
+++ b/src/lib/contract-calls.ts
@@ -192,6 +192,9 @@ export function buildSubmitView(
   campaignId: number,
   viewerAddress: string,
 ) {
+  if (campaignId < 0) throw new Error('buildSubmitView: campaignId must be non-negative');
+  if (!viewerAddress) throw new Error('buildSubmitView: viewerAddress is required');
+
   return {
     contractAddress: CONTRACT_ADDRESS,
     contractName: CONTRACTS.STATS_TRACKER,

--- a/src/lib/contract-calls.ts
+++ b/src/lib/contract-calls.ts
@@ -685,6 +685,11 @@ export function buildCreateSegment(
   minReputation: number,
   requireVerified: boolean,
 ) {
+  if (campaignId < 0) throw new Error('buildCreateSegment: campaignId must be non-negative');
+  if (!name || name.length === 0) throw new Error('buildCreateSegment: name is required');
+  if (name.length > 64) throw new Error('buildCreateSegment: name exceeds max length (64)');
+  if (minReputation < 0 || minReputation > 100) throw new Error('buildCreateSegment: minReputation must be 0-100');
+
   return {
     contractAddress: CONTRACT_ADDRESS,
     contractName: CONTRACTS.AUDIENCE_SELECTOR,

--- a/src/lib/contract-calls.ts
+++ b/src/lib/contract-calls.ts
@@ -1028,6 +1028,10 @@ export function buildReleaseToPublisher(
   publisherAddress: string,
   amount: number,
 ) {
+  if (campaignId < 0) throw new Error('buildReleaseToPublisher: campaignId must be non-negative');
+  if (!publisherAddress) throw new Error('buildReleaseToPublisher: publisherAddress is required');
+  if (amount <= 0) throw new Error('buildReleaseToPublisher: amount must be positive');
+
   return {
     contractAddress: CONTRACT_ADDRESS,
     contractName: CONTRACTS.FUNDS_KEEPER,

--- a/src/lib/env-validation.ts
+++ b/src/lib/env-validation.ts
@@ -63,11 +63,22 @@ export function validateEnv(): EnvConfig {
     }
   }
 
+  // Validate contract address matches network prefix
+  if (contractAddress) {
+    const expectedPrefix = network === 'mainnet' ? 'SP' : 'ST';
+    if (!contractAddress.startsWith(expectedPrefix)) {
+      console.warn(
+        `[env] Contract address "${contractAddress}" uses wrong prefix for ${network}. ` +
+        `Expected "${expectedPrefix}" prefix.`
+      );
+    }
+  }
+
   return {
     network,
-    contractAddress: contractAddress || 'SP3BXJENEWVNCFYGJF75DFS478H1BZJXNZPT84EAD',
-    apiUrl: apiUrl || 'https://api.hiro.so',
-    walletConnectProjectId: walletConnectId || 'demo-project-id',
+    contractAddress: contractAddress || (network === 'devnet' ? 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM' : 'SP3BXJENEWVNCFYGJF75DFS478H1BZJXNZPT84EAD'),
+    apiUrl: apiUrl || (network === 'devnet' ? 'http://localhost:3999' : 'https://api.hiro.so'),
+    walletConnectProjectId: walletConnectId || '',
   };
 }
 

--- a/src/lib/fee-estimator.ts
+++ b/src/lib/fee-estimator.ts
@@ -64,11 +64,17 @@ export async function estimateTransactionFee(
   const apiUrl = getApiUrl(network);
 
   try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10_000);
+
     const response = await fetch(`${apiUrl}/v2/fees/transaction`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: transactionBytes,
+      signal: controller.signal,
     });
+
+    clearTimeout(timeoutId);
 
     if (!response.ok) {
       return applyMultiplier(MIN_TX_FEE, multiplier);

--- a/src/lib/hiro-api.ts
+++ b/src/lib/hiro-api.ts
@@ -106,25 +106,36 @@ export interface MempoolTransaction {
 // Base Fetcher
 // ---------------------------------------------------------------------------
 
+const DEFAULT_API_TIMEOUT_MS = 30_000;
+
 async function apiFetch<T>(
   path: string,
   network?: SupportedNetwork,
   init?: RequestInit,
 ): Promise<T> {
   const url = `${getApiUrl(network)}${path}`;
-  const response = await fetch(url, {
-    ...init,
-    headers: {
-      'Content-Type': 'application/json',
-      ...(init?.headers ?? {}),
-    },
-  });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), DEFAULT_API_TIMEOUT_MS);
 
-  if (!response.ok) {
-    throw new Error(`Hiro API error ${response.status}: ${url}`);
+  try {
+    const response = await fetch(url, {
+      ...init,
+      signal: init?.signal ?? controller.signal,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(init?.headers ?? {}),
+      },
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => '');
+      throw new Error(`Hiro API error ${response.status}: ${url}${errorBody ? ` - ${errorBody}` : ''}`);
+    }
+
+    return response.json() as Promise<T>;
+  } finally {
+    clearTimeout(timeoutId);
   }
-
-  return response.json();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/nonce-manager.ts
+++ b/src/lib/nonce-manager.ts
@@ -32,14 +32,33 @@ export async function fetchAccountNonce(
   address: string,
   network?: SupportedNetwork,
 ): Promise<AccountNonces> {
-  const apiUrl = getApiUrl(network);
-  const response = await fetch(`${apiUrl}/extended/v1/address/${address}/nonces`);
-
-  if (!response.ok) {
-    throw new Error(`Failed to fetch nonce for ${address}: ${response.statusText}`);
+  if (!address || address.length === 0) {
+    throw new Error('fetchAccountNonce: address is required');
   }
 
-  return response.json();
+  const apiUrl = getApiUrl(network);
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 15_000);
+
+  try {
+    const response = await fetch(`${apiUrl}/extended/v1/address/${address}/nonces`, {
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch nonce for ${address}: ${response.statusText}`);
+    }
+
+    const data: AccountNonces = await response.json();
+
+    if (typeof data.possible_next_nonce !== 'number') {
+      throw new Error(`Invalid nonce response for ${address}: missing possible_next_nonce`);
+    }
+
+    return data;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }
 
 /**

--- a/src/lib/nonce-manager.ts
+++ b/src/lib/nonce-manager.ts
@@ -101,17 +101,36 @@ export function releaseNonce(address: string): void {
   pendingNonces.delete(address);
 }
 
+/** Lock map to prevent concurrent acquireNonce calls for the same address */
+const nonceLocks = new Map<string, Promise<bigint>>();
+
 /**
  * Get and reserve the next nonce atomically.
  * Returns the nonce ready for use in a transaction.
+ * Uses a per-address lock to prevent race conditions where two
+ * concurrent calls could acquire the same nonce.
  */
 export async function acquireNonce(
   address: string,
   network?: SupportedNetwork,
 ): Promise<bigint> {
-  const nonce = await getNextNonce(address, network);
-  reserveNonce(address, nonce);
-  return nonce;
+  const existingLock = nonceLocks.get(address);
+
+  const acquirePromise = (existingLock ?? Promise.resolve(0n)).then(async () => {
+    const nonce = await getNextNonce(address, network);
+    reserveNonce(address, nonce);
+    return nonce;
+  });
+
+  nonceLocks.set(address, acquirePromise);
+
+  try {
+    return await acquirePromise;
+  } finally {
+    if (nonceLocks.get(address) === acquirePromise) {
+      nonceLocks.delete(address);
+    }
+  }
 }
 
 /**

--- a/src/lib/post-conditions.ts
+++ b/src/lib/post-conditions.ts
@@ -29,6 +29,12 @@ export function createSTXTransferExact(
   senderAddress: string,
   amountSTX: number,
 ) {
+  if (!senderAddress || senderAddress.length === 0) {
+    throw new Error('createSTXTransferExact: senderAddress is required');
+  }
+  if (amountSTX <= 0 || !Number.isFinite(amountSTX)) {
+    throw new Error('createSTXTransferExact: amountSTX must be a positive finite number');
+  }
   const microAmount = BigInt(Math.floor(amountSTX * MICRO_STX));
   return Pc.principal(senderAddress).willSendEq(microAmount).ustx();
 }

--- a/src/lib/post-conditions.ts
+++ b/src/lib/post-conditions.ts
@@ -47,6 +47,12 @@ export function createSTXTransferMax(
   senderAddress: string,
   maxSTX: number,
 ) {
+  if (!senderAddress || senderAddress.length === 0) {
+    throw new Error('createSTXTransferMax: senderAddress is required');
+  }
+  if (maxSTX <= 0 || !Number.isFinite(maxSTX)) {
+    throw new Error('createSTXTransferMax: maxSTX must be a positive finite number');
+  }
   const microAmount = BigInt(Math.floor(maxSTX * MICRO_STX));
   return Pc.principal(senderAddress).willSendLte(microAmount).ustx();
 }

--- a/src/lib/post-conditions.ts
+++ b/src/lib/post-conditions.ts
@@ -65,6 +65,12 @@ export function createContractSTXTransfer(
   contractName: ContractName,
   maxSTX: number,
 ) {
+  if (!contractName || contractName.length === 0) {
+    throw new Error('createContractSTXTransfer: contractName is required');
+  }
+  if (maxSTX <= 0 || !Number.isFinite(maxSTX)) {
+    throw new Error('createContractSTXTransfer: maxSTX must be a positive finite number');
+  }
   const microAmount = BigInt(Math.floor(maxSTX * MICRO_STX));
   const contractPrincipal = `${CONTRACT_ADDRESS}.${contractName}`;
   return Pc.principal(contractPrincipal).willSendLte(microAmount).ustx();

--- a/src/lib/stacks-config.ts
+++ b/src/lib/stacks-config.ts
@@ -13,8 +13,13 @@ export const NETWORKS = {
 
 export type NetworkType = keyof typeof NETWORKS;
 
+const envNetwork = process.env.NEXT_PUBLIC_NETWORK as string | undefined;
+const validNetworks: NetworkType[] = ['mainnet', 'testnet', 'devnet'];
+
 export const CURRENT_NETWORK: NetworkType =
-  (process.env.NEXT_PUBLIC_NETWORK as NetworkType) || 'mainnet';
+  envNetwork && validNetworks.includes(envNetwork as NetworkType)
+    ? (envNetwork as NetworkType)
+    : 'mainnet';
 
 export const NETWORK: StacksNetwork = NETWORKS[CURRENT_NETWORK];
 

--- a/src/lib/stacks-config.ts
+++ b/src/lib/stacks-config.ts
@@ -136,6 +136,9 @@ export function estimateBlockTime(
   currentBlock: number,
   currentTimestamp: number,
 ): Date {
+  if (targetBlock < 0 || currentBlock < 0 || currentTimestamp < 0) {
+    throw new RangeError('estimateBlockTime: all parameters must be non-negative');
+  }
   const blockDelta = targetBlock - currentBlock;
   const secondsDelta = blockDelta * BLOCK_TIME.SECONDS_PER_BLOCK;
   return new Date((currentTimestamp + secondsDelta) * 1000);

--- a/src/lib/stacks-config.ts
+++ b/src/lib/stacks-config.ts
@@ -29,8 +29,17 @@ export const NETWORK: StacksNetwork = NETWORKS[CURRENT_NETWORK];
  */
 const DEVNET_DEPLOYER = 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM';
 
+const envContractAddress = process.env.NEXT_PUBLIC_CONTRACT_ADDRESS;
+
+if (!envContractAddress && CURRENT_NETWORK === 'mainnet' && typeof console !== 'undefined') {
+  console.warn(
+    '[AdStack] NEXT_PUBLIC_CONTRACT_ADDRESS not set for mainnet. Using fallback address. ' +
+    'Set this environment variable before deploying to production.'
+  );
+}
+
 export const CONTRACT_ADDRESS =
-  process.env.NEXT_PUBLIC_CONTRACT_ADDRESS ||
+  envContractAddress ||
   (CURRENT_NETWORK === 'devnet' ? DEVNET_DEPLOYER : 'SP3BXJENEWVNCFYGJF75DFS478H1BZJXNZPT84EAD');
 
 /**

--- a/src/lib/stacks-config.ts
+++ b/src/lib/stacks-config.ts
@@ -121,7 +121,11 @@ export const WITHDRAWAL_COOLDOWN_BLOCKS = 12;
  * Convert a Clarity v4 stacks-block-time Unix timestamp to a JS Date.
  */
 export function blockTimeToDate(blockTime: number | bigint): Date {
-  return new Date(Number(blockTime) * 1000);
+  const timestamp = Number(blockTime);
+  if (timestamp < 0 || !Number.isFinite(timestamp)) {
+    throw new RangeError('blockTimeToDate: blockTime must be a non-negative finite number');
+  }
+  return new Date(timestamp * 1000);
 }
 
 /**

--- a/src/lib/stacks-config.ts
+++ b/src/lib/stacks-config.ts
@@ -154,6 +154,9 @@ export function microStxToStx(microStx: number | bigint): number {
 }
 
 export function stxToMicroStx(stx: number): bigint {
+  if (stx < 0 || !Number.isFinite(stx)) {
+    throw new RangeError('stxToMicroStx: stx must be a non-negative finite number');
+  }
   return BigInt(Math.floor(stx * MICRO_STX));
 }
 

--- a/src/lib/stacks-connect.ts
+++ b/src/lib/stacks-connect.ts
@@ -113,6 +113,9 @@ export function connectSignTransaction(
     onCancel?: () => void;
   } = {},
 ): void {
+  if (!txHex || txHex.length === 0) throw new Error('connectSignTransaction: txHex is required');
+  if (!/^[0-9a-fA-F]+$/.test(txHex)) throw new Error('connectSignTransaction: txHex must be valid hex');
+
   const network = getStacksNetwork(options.network);
 
   const signOptions: SignTransactionOptions = {

--- a/src/lib/stacks-connect.ts
+++ b/src/lib/stacks-connect.ts
@@ -51,6 +51,9 @@ export interface ConnectTransferOptions {
  * This triggers the installed wallet (Leather, Xverse, etc.) to sign.
  */
 export function connectContractCall(options: ConnectCallOptions): void {
+  if (!options.contractName) throw new Error('connectContractCall: contractName is required');
+  if (!options.functionName) throw new Error('connectContractCall: functionName is required');
+
   const network = getStacksNetwork(options.network);
 
   const callOptions: ContractCallOptions = {

--- a/src/lib/stacks-connect.ts
+++ b/src/lib/stacks-connect.ts
@@ -78,6 +78,9 @@ export function connectContractCall(options: ConnectCallOptions): void {
  * Open a Stacks Connect STX transfer dialog.
  */
 export function connectSTXTransfer(options: ConnectTransferOptions): void {
+  if (!options.recipient) throw new Error('connectSTXTransfer: recipient is required');
+  if (options.amount <= 0n) throw new Error('connectSTXTransfer: amount must be positive');
+
   const network = getStacksNetwork(options.network);
 
   const transferOptions: STXTransferOptions = {

--- a/src/lib/stacks-connect.ts
+++ b/src/lib/stacks-connect.ts
@@ -13,6 +13,7 @@ import {
   STXTransferOptions,
   SignTransactionOptions,
 } from '@stacks/connect';
+import { PostConditionMode } from '@stacks/transactions';
 import { getStacksNetwork, SupportedNetwork } from './stacks-network';
 import { CONTRACT_ADDRESS, APP_DETAILS, CONTRACTS } from './stacks-config';
 import type { ContractName } from './stacks-config';
@@ -60,7 +61,7 @@ export function connectContractCall(options: ConnectCallOptions): void {
     network,
     appDetails: APP_DETAILS,
     postConditions: options.postConditions ?? [],
-    postConditionMode: options.postConditionMode === 'allow' ? 0x01 : 0x02,
+    postConditionMode: options.postConditionMode === 'allow' ? PostConditionMode.Allow : PostConditionMode.Deny,
     onFinish: options.onFinish
       ? (data) => options.onFinish!({ txId: data.txId, txRaw: data.txRaw })
       : undefined,
@@ -126,6 +127,6 @@ export function connectSignTransaction(
 // ---------------------------------------------------------------------------
 
 export const PC_MODE = {
-  DENY: 0x02 as const,
-  ALLOW: 0x01 as const,
+  DENY: PostConditionMode.Deny,
+  ALLOW: PostConditionMode.Allow,
 };

--- a/src/lib/stacks-network.ts
+++ b/src/lib/stacks-network.ts
@@ -117,9 +117,12 @@ export function getExplorerAddressUrl(
   address: string,
   network?: SupportedNetwork,
 ): string {
+  if (!address || address.length === 0) {
+    throw new Error('getExplorerAddressUrl: address is required');
+  }
   const { explorerBaseUrl, name } = getNetworkConfig(network);
   const chain = name !== 'mainnet' ? `?chain=${name}` : '';
-  return `${explorerBaseUrl}/address/${address}${chain}`;
+  return `${explorerBaseUrl}/address/${encodeURIComponent(address)}${chain}`;
 }
 
 /**

--- a/src/lib/stacks-network.ts
+++ b/src/lib/stacks-network.ts
@@ -101,10 +101,13 @@ export function getExplorerTxUrl(
   txId: string,
   network?: SupportedNetwork,
 ): string {
+  if (!txId || txId.length === 0) {
+    throw new Error('getExplorerTxUrl: txId is required');
+  }
   const { explorerBaseUrl, name } = getNetworkConfig(network);
   const chain = name !== 'mainnet' ? `?chain=${name}` : '';
   const normalizedTxId = txId.startsWith('0x') ? txId : `0x${txId}`;
-  return `${explorerBaseUrl}/txid/${normalizedTxId}${chain}`;
+  return `${explorerBaseUrl}/txid/${encodeURIComponent(normalizedTxId)}${chain}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Comprehensive security audit and fix pass across all 9 Clarity smart contracts and the frontend Stacks SDK integration layer. This PR addresses critical reentrancy vulnerabilities, missing input validation, authorization gaps, and frontend-contract alignment issues.

### Clarity Contract Fixes
- **Reentrancy prevention**: Reordered state updates before STX transfers in funds-keeper, cash-distributor, and promo-manager following the checks-effects-interactions pattern
- **Authorization fixes**: Removed redundant auth checks, added missing auth to update-activity and increment-campaigns in user-profiles
- **Underflow protection**: Added guards in partner-hub (pause/terminate) and promo-manager (cancel/complete-expired) to prevent unsigned integer underflow
- **Input validation**: Added missing validation for language, audience-size, evidence-hash, message fields across contracts
- **Error codes**: Added dedicated error codes (ERR_NOT_BLOCKED, ERR_ZERO_AMOUNT, ERR_SELF_PAYOUT, ERR_CONTRACT_PAUSED, etc.) for clearer error reporting
- **Event emission**: Added missing print events to add-segment-tag, add-publisher-tag, record-match-score, record-activity
- **Rate limiting**: Added flag submission cooldown in threat-detector to prevent spam flagging
- **Governance**: Increased quorum threshold from 3 to 10, added minimum passing margin requirement
- **Bug fixes**: Fixed self-transfer in cash-distributor claim-payout, fixed unwrap-panic usage in audience-selector
- **Missing functions**: Added deactivate-campaign-enrollment to partner-hub
- **Duplicate prevention**: Added duplicate enrollment check in partner-hub enroll-campaign

### Frontend Integration Fixes
- **PostConditionMode**: Replaced magic hex values (0x01/0x02) with proper SDK enums
- **API timeouts**: Added AbortController timeouts to hiro-api, nonce-manager, fee-estimator
- **Nonce race protection**: Added per-address locking in acquireNonce to prevent duplicate nonces
- **Input validation**: Added validation to all contract-call builders (campaign, payout, proposal, segment, partnership, earnings, etc.)
- **Clarity value bounds**: Added uint128/int128 bounds checking, principal format validation, list size limits, string length limits
- **Config safety**: Added network validation, mainnet address warning, WalletConnect project ID error
- **URL security**: Added encodeURIComponent to explorer URL builders
- **Transaction status**: Added 'dropped' status handling in use-tx-status hook

### Clarinet Configuration
- Fixed epoch from 'latest' to '3.0' for reproducible builds
- Added depends_on declarations for correct contract deployment ordering

## Test Plan
- [ ] Run `clarinet check` to verify all contracts compile
- [ ] Run `clarinet test` to verify contract test suite passes
- [ ] Run `npm run build` to verify frontend builds without errors
- [ ] Run `npm test` to verify frontend test suite passes
- [ ] Manual testing of wallet connection and transaction flows on devnet